### PR TITLE
Include environment vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: ./
         with:
           full_text: PROD=0
+          include_env_vars: true
         env:
           ACTION_CREATE_ENV_TEST: 1
       - run: cat .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,6 @@ jobs:
         with:
           full_text: PROD=0
         env:
-          TEST: 1
+          ACTION_CREATE_ENV_TEST: 1
       - run: cat .env
       - run: grep -zP "^PROD=0\nTEST=1$" .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,3 +69,20 @@ jobs:
           full_text: TEST=1
       - run: cat .env
       - run: grep -zP "^TEST=1$" .env
+  test-including-env-vars:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - uses: ./
+        with:
+          full_text: PROD=0
+        env:
+          TEST: 1
+      - run: cat .env
+      - run: grep -zP "^PROD=0\nTEST=1$" .env

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,11 @@ inputs:
   directory:
     description: 'Directory to write the file to (defaults to .). Parent directories will NOT be created.'
     default: '.'
+  include_env_vars:
+    required: false
+    description: |
+      If set, environemnt vars starting with ACTION_CREATE_ENV_ will be included (i.e. ACTION_CREATE_ENV_PROD=1 will be incldued in .env as PROD=1).
+      Vars set in this way are written after <full_text>.
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,21 +2,42 @@ import { getInput, info, setFailed } from '@actions/core'
 import dedent from 'dedent'
 import * as fs from 'fs'
 
+const ENV_PREFIX = 'ACTION_CREATE_ENV_'
+
 export interface Args {
   full_text: string
   directory: string
+  include_env_vars: boolean
 }
 
-export async function writeEnv(args: Args): Promise<void> {
+function getTextForEnvFile(args: Args) {
+  let text = dedent(args.full_text).trim()
+  if (args.include_env_vars) {
+    const envVars = Object.entries(process.env)
+      .filter(([key]) => key.startsWith(ENV_PREFIX))
+      .map(([key, val]) => {
+        const newKey = key.replace(new RegExp(`^${ENV_PREFIX}`), '')
+        return `${newKey}=${val}`
+      })
+    text += `\n${envVars.join('\n')}`
+  }
+  return text.trim()
+}
+
+function validateArgs(args: Args) {
+  if (!fs.existsSync(args.directory)) {
+    throw new Error(`Invalid directory input: ${args.directory} doesn't exist.`)
+  }
+  if (!fs.statSync(args.directory).isDirectory()) {
+    throw new Error(`Invalid directory input: ${args.directory} is not a directory.`)
+  }
+}
+
+export async function writeToEnvFile(args: Args): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    if (!fs.existsSync(args.directory)) {
-      throw new Error(`Invalid directory input: ${args.directory} doesn't exist.`)
-    }
-    if (!fs.statSync(args.directory).isDirectory()) {
-      throw new Error(`Invalid directory input: ${args.directory} is not a directory.`)
-    }
+    validateArgs(args)
     const filePath = `${args.directory}/.env`
-    const text = dedent(args.full_text).trim()
+    const text = getTextForEnvFile(args)
     fs.writeFile(filePath, text, err => {
       if (err) return reject(err)
       resolve()
@@ -28,10 +49,11 @@ export async function run(): Promise<void> {
   try {
     const args: Args = {
       full_text: getInput('full_text'),
-      directory: getInput('directory')
+      directory: getInput('directory'),
+      include_env_vars: !!getInput('include_env_vars')
     }
     info(`Creating .env file in ${args.directory}`)
-    await writeEnv(args)
+    await writeToEnvFile(args)
     info('Done.')
   } catch (error) {
     setFailed(error.message)


### PR DESCRIPTION
```yml
include_env_vars:
  required: false
  description: |
    If set, environemnt vars starting with ACTION_CREATE_ENV_ will be included (i.e. ACTION_CREATE_ENV_PROD=1 will be incldued in .env as PROD=1).
    Vars set in this way are written after <full_text>.
```